### PR TITLE
Update build folders

### DIFF
--- a/assets/launch.json
+++ b/assets/launch.json
@@ -1,6 +1,5 @@
 {
   "XCODE_SCHEME_NAME": "",
-  "XCODE_PROJECT": "",
   "APP_IDENTIFIER": "",
   "APPLE_ID": "",
   "FASTLANE_PASSWORD": "",
@@ -9,7 +8,6 @@
   "CERT_PASSWORD": "",
   "SLACK_URL": "",
   "SLACK_ROOM": "",
-  "ANDROID_BUILD_FOLDER": "",
   "ANDROID_KEY": "",
   "ANDROID_STORE_PASS": "",
   "ANDROID_ZIPALIGN": "",

--- a/docs/actions/build/README.md
+++ b/docs/actions/build/README.md
@@ -42,14 +42,12 @@ If you are targeting the Android platform, fill out these variables in your `lau
 
 ```json
 {
-  "ANDROID_BUILD_FOLDER": ".build/android",
   "ANDROID_STORE_PASS": "password",
   "ANDROID_KEY": "name-of-key",
   "ANDROID_ZIPALIGN": "/path/to/android/sdk/build-tools/23.0.3/zipalign"
 }
 ```
 
-- `ANDROID_BUILD_FOLDER`: should be exactly that `.build/android`
 - `ANDROID_STORE_KEY`: the name of the key generated for signing your android app. To generate a key, run this command, replacing `your-app-name` with your app name:
 
 ```shell

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -57,7 +57,6 @@ Let's start filling out our variables in the `launch.json` file. Below is what w
 ```json
 {
   "APP_IDENTIFIER": "cc.newspring.LaunchBasicExample",
-  "ANDROID_BUILD_FOLDER": ".build/android",
   "ANDROID_KEY": "launch-basic-example",
   "ANDROID_STORE_PASS": "password",
   "ANDROID_HOCKEY_TOKEN": "215d3df4b2ba4090918115207c13d718",
@@ -67,7 +66,7 @@ Let's start filling out our variables in the `launch.json` file. Below is what w
 }
 ```
 
-`APP_IDENTIFIER` will be whatever you like, and `ANDROID_BUILD_FOLDER` needs to be exactly that. Let's generate the `ANDROID_KEY` and `ANDROID_STORE_PASS`.
+`APP_IDENTIFIER` can be what you like, but is generally defined in the backwards domain style (com.example.app). Let's generate the `ANDROID_KEY` and `ANDROID_STORE_PASS`.
 
 #### Android
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,7 +34,7 @@ platform :ios do
     )
 
     update_project_provisioning(
-      xcodeproj: ENV['XCODE_PROJECT'],
+      xcodeproj: ".build/ios/project/#{ENV['XCODE_SCHEME_NAME']}.xcodeproj",
       profile: lane_context[SharedValues::SIGH_PROFILE_PATH],
       target_filter: ENV['XCODE_SCHEME_NAME'],
       build_configuration: "Release"
@@ -42,7 +42,7 @@ platform :ios do
 
     gym(
       scheme: ENV['XCODE_SCHEME_NAME'],
-      project: ENV['XCODE_PROJECT'],
+      project: ".build/ios/project/#{ENV['XCODE_SCHEME_NAME']}.xcodeproj",
       include_bitcode: false
     )
   end
@@ -56,7 +56,7 @@ platform :ios do
     )
 
     update_project_provisioning(
-      xcodeproj: ENV['XCODE_PROJECT'],
+      xcodeproj: ".build/ios/project/#{ENV['XCODE_SCHEME_NAME']}.xcodeproj",
       profile: lane_context[SharedValues::SIGH_PROFILE_PATH],
       target_filter: ENV['XCODE_SCHEME_NAME'],
       build_configuration: "Release"
@@ -65,7 +65,7 @@ platform :ios do
     gym(
       use_legacy_build_api: true,
       scheme: ENV['XCODE_SCHEME_NAME'],
-      project: ENV['XCODE_PROJECT'],
+      project: ".build/ios/project/#{ENV['XCODE_SCHEME_NAME']}.xcodeproj",
       include_bitcode: false,
       export_method: "ad-hoc"
     )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-launch",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Automating meteor builds to the AppStore, TestFlight, Hockey, Google Play, and more later.",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/hockey.js
+++ b/src/hockey.js
@@ -31,7 +31,7 @@ const uploadAndroid = (env) => (
     const uploadCommand = `
       curl -F "status=2" \
         -F "notify=0" \
-        -F "ipa=@$ANDROID_BUILD_FOLDER/production.apk" \
+        -F "ipa=@.build/android/production.apk" \
         -H "X-HockeyAppToken: $ANDROID_HOCKEY_TOKEN" \
         https://rink.hockeyapp.net/api/2/apps/${env.ANDROID_HOCKEY_ID}/app_versions/upload
     `;

--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,7 @@ if (util.launchFile()) {
     SIGH_OUTPUT_PATH: process.cwd(),
     GYM_OUTPUT_DIRECTORY: process.cwd(),
     FL_REPORT_PATH: join(process.cwd(), ".build", "ios"),
-    // convert relative paths to abslute
-    XCODE_PROJECT: resolve(launchVars.XCODE_PROJECT),
+    XCODE_PROJECT: resolve(".build", "ios", "project", `${launchVars.XCODE_SCHEME_NAME}.xcodeproj`),
   };
   superEnv = extend(launchVars, otherVars, process.env);
 }

--- a/src/play.js
+++ b/src/play.js
@@ -19,7 +19,7 @@ const uploadPlayStore = (env) => (
     const playCommand = `
       playup \
         --auth $PLAY_AUTH_FILE \
-        $ANDROID_BUILD_FOLDER/production.apk
+        .build/android/production.apk
     `;
     execSync(playCommand, {
       stdio: [0, 1, 2],


### PR DESCRIPTION
This removes the confusion created by allowing the xcode project and android build folder paths to be set in the `launch.json` file. These variables can only be derivatives of the `.build` folder at this point, and therefore we can hard code them for now.

Temporary fix for the confusion in #30 