### PR TITLE
Crosswalk Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 0.2.7
+
+* Standalone action for preparing Android SDKs
+* Crosswalk support for all Android actions (signing, aligning, Hockey, Google Play)

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ $ launch testflight
 - [Docs site](http://newspring.github.io/meteor-launch/)
 - [Sample project](https://github.com/NewSpring/launch-basic-example)
 - [Sample project 2](https://github.com/NewSpring/launch-todos-example)
+- [Sample project 3](https://github.com/NewSpring/launch-crosswalk-example)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -11,4 +11,5 @@
 * [Continuous Deployment](/cd/README.md)
 * [Examples](/examples/README.md)
   * [Basic](/examples/README.md#basic)
+  * [Crosswalk](/example/README.md#crosswalk)
   * [Kitchen Sink](/examples/README.md#kitchen-sink)

--- a/docs/actions/hockey/README.md
+++ b/docs/actions/hockey/README.md
@@ -32,3 +32,5 @@ Generate an API key for your Android app on Hockey. You will also need the id of
   "ANDROID_HOCKEY_ID": "idhere"
 }
 ```
+*Crosswalk*: If you use the Crosswalk webview, two different builds of your app are generated. Both of these will be uploaded to Hockey with different build numbers.
+

--- a/docs/actions/playstore/README.md
+++ b/docs/actions/playstore/README.md
@@ -17,3 +17,4 @@ You will need to generate an auth file to allow uploading. To do this, navigate 
   "PLAY_AUTH_FILE": ""
 }
 ```
+*Crosswalk*: If you use the Crosswalk webview, two different builds of your app are generated. Both of these will be uploaded to Google Play with different build numbers.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -176,6 +176,21 @@ Finally, push your repo to GitHub, turn builds on for this project on Travis, an
 
 ---
 
+## Crosswalk
+
+In this example, we are going to use Travis to:
+
+1. Deploy server to Galaxy
+2. Build an Android app using Crosswalk
+3. Distribute app through [Hockey](https://hockeyapp.net)
+
+Setting up these actions are detailed about in the Basic example. Here are all the finished items:
+
+1. [Code on GitHub](https://github.com/NewSpring/launch-crosswalk-example)
+2. [Build on Travis](https://travis-ci.org/NewSpring/launch-crosswalk-example)
+3. [Site on Heroku](https://launch-crosswalk-example.herokuapp.com/)
+4. [App download on Hockey](https://rink.hockeyapp.net/apps/b8ce93866d44406d950cf9a390b235e1)
+
 ## Kitchen Sink
 
 In this example, we are going to use Travis's build matrix to:

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/NewSpring/meteor-launch#readme",
   "dependencies": {
+    "rimraf": "^2.5.4",
     "underscore": "^1.8.3",
     "vorpal": "^1.11.2"
   },

--- a/src/android.js
+++ b/src/android.js
@@ -1,5 +1,86 @@
 import { execSync } from "child_process";
+import rimraf from "rimraf";
+import { statSync } from "fs";
 import util from "./util";
+
+const buildFolder = {
+  root: "./.build/android",
+  crosswalk: "./.build/android/project/build/outputs/apk",
+};
+
+const unsignedApks = {
+  regular: `${buildFolder.root}/release-unsigned.apk`,
+  crosswalkArmv7: `${buildFolder.crosswalk}/android-armv7-release-unsigned.apk`,
+  crosswalkX86: `${buildFolder.crosswalk}/android-x86-release-unsigned.apk`,
+};
+
+const signedApks = {
+  regular: `${buildFolder.root}/production.apk`,
+  crosswalkArmv7: `${buildFolder.root}/production-armv7.apk`,
+  crosswalkX86: `${buildFolder.root}/production-x86.apk`,
+};
+
+const removeApks = () => {
+  console.log("Removing existing apk...");
+  Object.keys(signedApks).map((apk) => {
+    rimraf.sync(signedApks[apk]);
+  });
+};
+
+const findCrosswalkApks = () => {
+  try {
+    statSync(unsignedApks.crosswalkArmv7);
+    statSync(unsignedApks.crosswalkX86);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+const getSignCommands = (isCrosswalk) => {
+  const signCommand = (apkPath) => {
+    return `
+      jarsigner -verbose \
+        -sigalg SHA1withRSA \
+        -digestalg SHA1 \
+        -storepass $ANDROID_STORE_PASS \
+        ${apkPath} \
+        $ANDROID_KEY
+    `;
+  }
+
+  if (isCrosswalk) {
+    return [
+      signCommand(unsignedApks.crosswalkArmv7),
+      signCommand(unsignedApks.crosswalkX86),
+    ];
+  } else {
+    return [
+      signCommand(unsignedApks.regular),
+    ];
+  }
+};
+
+const getAlignCommands = (isCrosswalk) => {
+  const alignCommand = (apkPath, output) => {
+    return `
+      $ANDROID_ZIPALIGN 4 \
+        ${apkPath} \
+        ${output}
+    `;
+  };
+
+  if (isCrosswalk) {
+    return [
+      alignCommand(unsignedApks.crosswalkArmv7, signedApks.crosswalkArmv7),
+      alignCommand(unsignedApks.crosswalkX86, signedApks.crosswalkX86),
+    ];
+  } else {
+    return [
+      alignCommand(unsignedApks.regular, signedApks.regular),
+    ];
+  }
+};
 
 const prepareApk = (env) => (
   new Promise((resolve) => {
@@ -8,39 +89,24 @@ const prepareApk = (env) => (
       return resolve();
     }
 
-    console.log("Removing existing apk...");
-    try {
-      execSync("rm .build/android/production.apk", {
+    removeApks();
+
+    const isCrosswalk = findCrosswalkApks();
+
+    console.log("Signing Android apk...");
+    getSignCommands(isCrosswalk).map((command) => {
+      execSync(command, {
         stdio: [0, 1, 2],
         env,
       });
-    } catch (error) {
-      console.log("No apk to remove...");
-    }
-
-    console.log("Signing Android apk...");
-    const signCommand = `
-      jarsigner -verbose \
-        -sigalg SHA1withRSA \
-        -digestalg SHA1 \
-        -storepass $ANDROID_STORE_PASS \
-        .build/android/release-unsigned.apk \
-        $ANDROID_KEY
-    `;
-    execSync(signCommand, {
-      stdio: [0, 1, 2],
-      env,
     });
 
     console.log("Aligning Android apk...");
-    const alignCommand = `
-      $ANDROID_ZIPALIGN 4 \
-        .build/android/release-unsigned.apk \
-        .build/android/production.apk
-    `;
-    execSync(alignCommand, {
-      stdio: [0, 1, 2],
-      env,
+    getAlignCommands(isCrosswalk).map((command) => {
+      execSync(command, {
+        stdio: [0, 1, 2],
+        env,
+      });
     });
 
     return resolve();

--- a/src/android.js
+++ b/src/android.js
@@ -22,9 +22,9 @@ const signedApks = {
 
 const removeApks = () => {
   console.log("Removing existing apk...");
-  Object.keys(signedApks).map((apk) => {
-    rimraf.sync(signedApks[apk]);
-  });
+  Object.keys(signedApks).map((apk) => (
+    rimraf.sync(signedApks[apk])
+  ));
 };
 
 const findCrosswalkApks = () => {
@@ -38,48 +38,46 @@ const findCrosswalkApks = () => {
 };
 
 const getSignCommands = (isCrosswalk) => {
-  const signCommand = (apkPath) => {
-    return `
+  const signCommand = (apkPath) => (
+    `
       jarsigner -verbose \
         -sigalg SHA1withRSA \
         -digestalg SHA1 \
         -storepass $ANDROID_STORE_PASS \
         ${apkPath} \
         $ANDROID_KEY
-    `;
-  }
+    `
+  );
 
   if (isCrosswalk) {
     return [
       signCommand(unsignedApks.crosswalkArmv7),
       signCommand(unsignedApks.crosswalkX86),
     ];
-  } else {
-    return [
-      signCommand(unsignedApks.regular),
-    ];
   }
+  return [
+    signCommand(unsignedApks.regular),
+  ];
 };
 
 const getAlignCommands = (isCrosswalk) => {
-  const alignCommand = (apkPath, output) => {
-    return `
+  const alignCommand = (apkPath, output) => (
+    `
       $ANDROID_ZIPALIGN 4 \
         ${apkPath} \
         ${output}
-    `;
-  };
+    `
+  );
 
   if (isCrosswalk) {
     return [
       alignCommand(unsignedApks.crosswalkArmv7, signedApks.crosswalkArmv7),
       alignCommand(unsignedApks.crosswalkX86, signedApks.crosswalkX86),
     ];
-  } else {
-    return [
-      alignCommand(unsignedApks.regular, signedApks.regular),
-    ];
   }
+  return [
+    alignCommand(unsignedApks.regular, signedApks.regular),
+  ];
 };
 
 const prepareApk = (env) => (
@@ -94,20 +92,20 @@ const prepareApk = (env) => (
     const isCrosswalk = findCrosswalkApks();
 
     console.log("Signing Android apk...");
-    getSignCommands(isCrosswalk).map((command) => {
+    getSignCommands(isCrosswalk).map((command) => (
       execSync(command, {
         stdio: [0, 1, 2],
         env,
-      });
-    });
+      })
+    ));
 
     console.log("Aligning Android apk...");
-    getAlignCommands(isCrosswalk).map((command) => {
+    getAlignCommands(isCrosswalk).map((command) => (
       execSync(command, {
         stdio: [0, 1, 2],
         env,
-      });
-    });
+      })
+    ));
 
     return resolve();
   })

--- a/src/android.js
+++ b/src/android.js
@@ -115,4 +115,6 @@ const prepareApk = (env) => (
 
 export default {
   prepareApk,
+  findCrosswalkApks,
+  signedApks,
 };

--- a/src/hockey.js
+++ b/src/hockey.js
@@ -27,34 +27,34 @@ const uploadAndroid = (env) => (
       return resolve();
     }
 
-    const getCommand = (path) => {
-      return `
+    const getCommand = (path) => (
+      `
         curl -F "status=2" \
           -F "notify=0" \
           -F "ipa=@${path}" \
           -H "X-HockeyAppToken: $ANDROID_HOCKEY_TOKEN" \
           https://rink.hockeyapp.net/api/2/apps/${env.ANDROID_HOCKEY_ID}/app_versions/upload
       `
-    };
+    );
 
     console.log("Uploading Android to Hockey...");
 
     const isCrosswalk = android.findCrosswalkApks();
 
     const commands = isCrosswalk ?
-      [
-        getCommand(android.signedApks.crosswalkArmv7),
-        getCommand(android.signedApks.crosswalkX86),
-      ] :
+    [
+      getCommand(android.signedApks.crosswalkArmv7),
+      getCommand(android.signedApks.crosswalkX86),
+    ] :
       [getCommand(android.signedApks.regular)]
     ;
 
-    commands.map((command) => {
+    commands.map((command) => (
       execSync(command, {
         stdio: [0, 1, 2],
         env,
-      });
-    });
+      })
+    ));
 
     return resolve();
   })

--- a/src/hockey.js
+++ b/src/hockey.js
@@ -1,4 +1,5 @@
 import { execSync } from "child_process";
+import android from "./android";
 import util from "./util";
 
 const uploadIOS = (env) => (
@@ -26,18 +27,33 @@ const uploadAndroid = (env) => (
       return resolve();
     }
 
+    const getCommand = (path) => {
+      return `
+        curl -F "status=2" \
+          -F "notify=0" \
+          -F "ipa=@${path}" \
+          -H "X-HockeyAppToken: $ANDROID_HOCKEY_TOKEN" \
+          https://rink.hockeyapp.net/api/2/apps/${env.ANDROID_HOCKEY_ID}/app_versions/upload
+      `
+    };
+
     console.log("Uploading Android to Hockey...");
 
-    const uploadCommand = `
-      curl -F "status=2" \
-        -F "notify=0" \
-        -F "ipa=@.build/android/production.apk" \
-        -H "X-HockeyAppToken: $ANDROID_HOCKEY_TOKEN" \
-        https://rink.hockeyapp.net/api/2/apps/${env.ANDROID_HOCKEY_ID}/app_versions/upload
-    `;
-    execSync(uploadCommand, {
-      stdio: [0, 1, 2],
-      env,
+    const isCrosswalk = android.findCrosswalkApks();
+
+    const commands = isCrosswalk ?
+      [
+        getCommand(android.signedApks.crosswalkArmv7),
+        getCommand(android.signedApks.crosswalkX86),
+      ] :
+      [getCommand(android.signedApks.regular)]
+    ;
+
+    commands.map((command) => {
+      execSync(command, {
+        stdio: [0, 1, 2],
+        env,
+      });
     });
 
     return resolve();

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,13 @@ Launch
   });
 
 Launch
+  .command("prepare", "Prepares the Android apk files")
+  .action(() => {
+    android.prepareApk(superEnv)
+      .catch(error => console.log(error));
+  });
+
+Launch
   .command("hockey", "Deploy to Hockey")
   .action(() => {
     util.addFastfile()

--- a/src/play.js
+++ b/src/play.js
@@ -36,12 +36,12 @@ const uploadPlayStore = (env) => (
       [getCommand(android.signedApks.regular)]
     ;
 
-    commands.map((command) => {
+    commands.map((command) => (
       execSync(command, {
         stdio: [0, 1, 2],
         env,
-      });
-    });
+      })
+    ));
 
     return resolve();
   })

--- a/src/play.js
+++ b/src/play.js
@@ -1,4 +1,5 @@
 import { execSync } from "child_process";
+import android from "./android";
 import util from "./util";
 
 const uploadPlayStore = (env) => (
@@ -15,15 +16,31 @@ const uploadPlayStore = (env) => (
       execSync("npm install -g playup");
     }
 
+    const getCommand = (path) => (
+      `
+        playup \
+          --auth $PLAY_AUTH_FILE \
+          ${path}
+      `
+    );
+
     console.log("Uploading to Google Play Store...");
-    const playCommand = `
-      playup \
-        --auth $PLAY_AUTH_FILE \
-        .build/android/production.apk
-    `;
-    execSync(playCommand, {
-      stdio: [0, 1, 2],
-      env,
+
+    const isCrosswalk = android.findCrosswalkApks();
+
+    const commands = isCrosswalk ?
+    [
+      getCommand(android.signedApks.crosswalkArmv7),
+      getCommand(android.signedApks.crosswalkX86),
+    ] :
+      [getCommand(android.signedApks.regular)]
+    ;
+
+    commands.map((command) => {
+      execSync(command, {
+        stdio: [0, 1, 2],
+        env,
+      });
     });
 
     return resolve();


### PR DESCRIPTION
This aims to bring support for the Android Crosswalk webview to all launch actions. Crosswalk generates two separate APK files for distribution, instead of the single APK generated by vanilla Meteor builds. So, we need to handle both APKs.

This will resolve #46 and #47 

- [x] separate prepare action
- [x] prepare both APKs
- [x] upload both to Hockey
- [x] upload both to Google Play
- [x] add changelog
- [x] update docs
- [x] update/add examples